### PR TITLE
update typings for transport settings

### DIFF
--- a/typings/connection.d.ts
+++ b/typings/connection.d.ts
@@ -55,6 +55,10 @@ export interface ConnectionDetails {
    * @property {Function} connect The `connect` function of `"net"` or `"tls"` module.
    */
   connect?: Function;
+  /**
+   * @property {string} [transport] - The transport option.
+   */
+  transport?: "tls" | "ssl" | "tcp";
 }
 
 /**
@@ -88,7 +92,7 @@ export interface ConnectionOptions extends EndpointOptions {
    */
   port?: number;
   /**
-   * @property {string} [transport] - The transport option.
+   * @property {string} [transport] - The transport option. This is ignored if connection_details is set.
    */
   transport?: "tls" | "ssl" | "tcp";
   /**


### PR DESCRIPTION
- `transport` is ignored on the `ConnectionOptions` object if the `connection_details` method is set.
- on the `ConnectionDetails` value returned from the `connection_details` method, `transport` is actually looked for at the root level (`details.transport`, e.g.).  The typings previously suggested this was at `details.options.transport`